### PR TITLE
Migrate deprecated functions

### DIFF
--- a/src/jguides_2024/datajoint_nwb_utils/datajoint_table_base.py
+++ b/src/jguides_2024/datajoint_nwb_utils/datajoint_table_base.py
@@ -5,9 +5,10 @@ import datajoint as dj
 import numpy as np
 import pandas as pd
 
+from spyglass.utils.dj_mixin import SpyglassMixin, SpyglassMixinPart
 from jguides_2024.datajoint_nwb_utils.datajoint_table_helpers import get_table_name, make_param_name, \
     populate_flexible_key, get_upstream_table_names, \
-    insert_analysis_table_entry, fetch1_dataframe, fetch_nwb, plot_datajoint_table_rate_map, intersect_tables, \
+    insert_analysis_table_entry, fetch1_dataframe, plot_datajoint_table_rate_map, intersect_tables, \
     insert_manual_table_test_entry, get_meta_param_name, fetch1_dataframes, \
     trial_duration_from_params_table, insert1_print, fetch1_dataframe_from_table_entry, get_table_secondary_key_names, \
     package_secondary_key, get_schema_table_names_from_file, get_schema_names, \
@@ -36,7 +37,7 @@ populate, insert1, fetch1. So avoiding overriding datajoint table methods with t
 """
 
 
-class ParamsBase(dj.Manual):
+class ParamsBase(SpyglassMixin, dj.Manual):
 
     def _get_main_table(self):
         """
@@ -286,23 +287,17 @@ class SelBase(dj.Manual):
     def fetch1_dataframe(self, object_id_name=None, restore_empty_nwb_object=True, df_index_name=None):
         return fetch1_dataframe(self, object_id_name, restore_empty_nwb_object, df_index_name)
 
-    def fetch_nwb(self):
-        return fetch_nwb(self)
 
-
-class PartBase(dj.Part):
+class PartBase(SpyglassMixinPart):
 
     def fetch1_dataframe(self, object_id_name=None, restore_empty_nwb_object=True, df_index_name=None):
         return fetch1_dataframe(self, object_id_name, restore_empty_nwb_object, df_index_name)
-    
-    def fetch_nwb(self):
-        return fetch_nwb(self)
 
     def get_key(self, key):
         return intersect_tables([get_table(x) for x in get_upstream_table_names(self)], key).fetch1("KEY")
 
 
-class ComputedBase(dj.Computed):
+class ComputedBase(SpyglassMixin, dj.Computed):
 
     def _initialize_upstream_entries_tracker(self):
         self.upstream_obj = UpstreamEntries()
@@ -434,9 +429,6 @@ class ComputedBase(dj.Computed):
 
     def get_object_id_name(self, leave_out_object_id=False, unpack_single_object_id=True):
         return get_table_object_id_name(self, leave_out_object_id, unpack_single_object_id)
-
-    def fetch_nwb(self, **kwargs):
-        return fetch_nwb(self, **kwargs)
 
     @staticmethod
     def get_default_df_index_name(df_index_name, object_id_name, df_index_name_map):

--- a/src/jguides_2024/datajoint_nwb_utils/datajoint_table_helpers.py
+++ b/src/jguides_2024/datajoint_nwb_utils/datajoint_table_helpers.py
@@ -6,12 +6,10 @@ from collections.abc import Iterable
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 from datajoint import DataJointError
 from matplotlib import pyplot as plt
 from networkx import NetworkXError
 from spyglass.common import (AnalysisNwbfile, Session, IntervalList)
-from spyglass.utils.dj_helper_fn import fetch_nwb as fetch_nwb_
 
 from jguides_2024.datajoint_nwb_utils.metadata_helpers import get_environments, get_jguidera_nwbf_names
 from jguides_2024.utils.check_well_defined import check_one_none
@@ -66,11 +64,6 @@ def fetch1_tolerate_no_entry(table, attribute=None):
         return table.fetch1(attribute)
     else:
         return None
-
-
-def fetch_nwb(table, **kwargs):
-
-    return fetch_nwb_(table, (AnalysisNwbfile, 'analysis_file_abs_path'), **kwargs)
 
 
 def fetch1_dataframe_tolerate_no_entry(table_subset, object_name=None):

--- a/src/jguides_2024/edeno_decoder/jguidera_edeno_decoder_error.py
+++ b/src/jguides_2024/edeno_decoder/jguidera_edeno_decoder_error.py
@@ -4,7 +4,6 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 from spyglass.common import close_nwb_files, AnalysisNwbfile
 
 from jguides_2024.datajoint_nwb_utils.datajoint_analysis_helpers import get_subject_id, \

--- a/src/jguides_2024/edeno_decoder/jguidera_edeno_decoder_run.py
+++ b/src/jguides_2024/edeno_decoder/jguidera_edeno_decoder_run.py
@@ -10,7 +10,6 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 import xarray as xr
 from replay_trajectory_classification import ClusterlessClassifier, SortedSpikesClassifier
 from spyglass.common import IntervalList, IntervalLinearizedPosition, AnalysisNwbfile

--- a/src/jguides_2024/firing_rate_map/jguidera_ppt_firing_rate_map.py
+++ b/src/jguides_2024/firing_rate_map/jguidera_ppt_firing_rate_map.py
@@ -4,7 +4,6 @@ import datajoint as dj
 import numpy as np
 import pandas as pd
 import scipy as sp
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_map/jguidera_well_arrival_firing_rate_map.py
+++ b/src/jguides_2024/firing_rate_map/jguidera_well_arrival_firing_rate_map.py
@@ -1,7 +1,6 @@
 # This module defines tables with well arrival firing rate maps
 
 import datajoint as dj
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_difference_vector.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_difference_vector.py
@@ -1,7 +1,6 @@
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_difference_vector_similarity.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_difference_vector_similarity.py
@@ -2,7 +2,6 @@ import datajoint as dj
 import numpy as np
 import pandas as pd
 import scipy as sp
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_difference_vector_similarity_ave.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_difference_vector_similarity_ave.py
@@ -3,7 +3,6 @@ import copy
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_vector_embedding.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_firing_rate_vector_embedding.py
@@ -6,7 +6,6 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_multi_cov_firing_rate_vector.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_multi_cov_firing_rate_vector.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_path_firing_rate_vector.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_path_firing_rate_vector.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_path_firing_rate_vector_decode.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_path_firing_rate_vector_decode.py
@@ -1,5 +1,4 @@
 import datajoint as dj
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_post_delay_firing_rate_vector.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_post_delay_firing_rate_vector.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 
 import datajoint as dj
 import numpy as np
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_well_event_firing_rate_vector.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_well_event_firing_rate_vector.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 import datajoint as dj
 import numpy as np
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/firing_rate_vector/jguidera_well_event_firing_rate_vector_decode.py
+++ b/src/jguides_2024/firing_rate_vector/jguidera_well_event_firing_rate_vector_decode.py
@@ -1,5 +1,4 @@
 import datajoint as dj
-import spyglass as nd
 import numpy as np
 
 from spyglass.common import AnalysisNwbfile

--- a/src/jguides_2024/glm/jguidera_el_net.py
+++ b/src/jguides_2024/glm/jguidera_el_net.py
@@ -3,7 +3,6 @@ import copy
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 import statsmodels.api as sm
 
 from spyglass.common import AnalysisNwbfile

--- a/src/jguides_2024/glm/jguidera_measurements_interp_pool.py
+++ b/src/jguides_2024/glm/jguidera_measurements_interp_pool.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/metadata/jguidera_brain_region.py
+++ b/src/jguides_2024/metadata/jguidera_brain_region.py
@@ -1,7 +1,6 @@
 import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
-import spyglass as nd
 from spyglass.common import ElectrodeGroup, AnalysisNwbfile
 from spyglass.spikesorting.v0.spikesorting_recording import SortGroup
 

--- a/src/jguides_2024/position_and_maze/jguidera_position.py
+++ b/src/jguides_2024/position_and_maze/jguidera_position.py
@@ -4,9 +4,8 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 from spyglass.common.common_position import (IntervalLinearizedPosition, IntervalPositionInfo)
-from spyglass.utils.dj_helper_fn import fetch_nwb
+from spyglass.utils.dj_mixin import SpyglassMixinPart
 
 from spyglass.common import AnalysisNwbfile
 
@@ -132,7 +131,7 @@ class IntervalPositionInfoRelabel(ComputedBase):
     -> IntervalPositionInfoRelabelParams
     """
 
-    class RelabelEntries(dj.Part):
+    class RelabelEntries(SpyglassMixinPart):
         definition = """
         -> IntervalPositionInfoRelabel
         -> IntervalPositionInfo
@@ -145,10 +144,6 @@ class IntervalPositionInfoRelabel(ComputedBase):
 
         def fetch1_dataframe(self):
             return fetch1_dataframe_position_info(self)
-
-        def fetch_nwb(self, *attrs, **kwargs):
-            return fetch_nwb(self, (AnalysisNwbfile, 'analysis_file_abs_path'),
-                             *attrs, **kwargs)
 
     def make(self, key):
         relabel_params = (IntervalPositionInfoRelabelParams & key).fetch1()
@@ -259,7 +254,7 @@ class IntervalLinearizedPositionRelabel(ComputedBase):
     -> IntervalLinearizedPositionRelabelParams
     """
 
-    class RelabelEntries(dj.Part):
+    class RelabelEntries(SpyglassMixinPart):
         definition = """
         -> IntervalLinearizedPositionRelabel
         -> IntervalLinearizedPosition
@@ -270,10 +265,6 @@ class IntervalLinearizedPositionRelabel(ComputedBase):
 
         def fetch1_dataframe(self):
             return fetch1_dataframe(self, 'linearized_position').set_index('time')
-
-        def fetch_nwb(self, *attrs, **kwargs):
-            return fetch_nwb(self, (AnalysisNwbfile, 'analysis_file_abs_path'),
-                             *attrs, **kwargs)
 
     def make(self, key):
         relabel_params = (IntervalLinearizedPositionRelabelParams & key).fetch1()

--- a/src/jguides_2024/position_and_maze/jguidera_ppt.py
+++ b/src/jguides_2024/position_and_maze/jguidera_ppt.py
@@ -4,7 +4,6 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/position_and_maze/jguidera_ppt_interp.py
+++ b/src/jguides_2024/position_and_maze/jguidera_ppt_interp.py
@@ -1,6 +1,5 @@
 import datajoint as dj
 import numpy as np
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/spike_sorting_curation/jguidera_artifact.py
+++ b/src/jguides_2024/spike_sorting_curation/jguidera_artifact.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
 import spikeinterface as si
-import spyglass as nd
 from spyglass.common import IntervalList
 from spyglass.spikesorting.v0.spikesorting_artifact import (ArtifactDetectionSelection,
                                                             ArtifactRemovedIntervalList,
@@ -484,7 +483,7 @@ def populate_ArtifactDetectionParameters():
     global_artifact_detection_params = return_global_artifact_detection_params()
     for artifact_params_name, artifact_params in global_artifact_detection_params.items():
         for prefix in ["", "group_"]:
-            nd.spikesorting.v0.spikesorting_artifact.ArtifactDetectionParameters.insert1(
+            ArtifactDetectionParameters.insert1(
                 {"artifact_params_name": prefix + artifact_params_name, "artifact_params": artifact_params},
                 skip_duplicates=True)
 

--- a/src/jguides_2024/spikes/jguidera_res_spikes.py
+++ b/src/jguides_2024/spikes/jguidera_res_spikes.py
@@ -4,7 +4,6 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/spikes/jguidera_spikes.py
+++ b/src/jguides_2024/spikes/jguidera_spikes.py
@@ -5,7 +5,6 @@ import copy
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 from spyglass.common import IntervalList, AnalysisNwbfile
 from spyglass.spikesorting.v0.spikesorting_curation import SortInterval, CuratedSpikeSorting
 

--- a/src/jguides_2024/task_event/jguidera_task_value.py
+++ b/src/jguides_2024/task_event/jguidera_task_value.py
@@ -4,7 +4,6 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/time_and_trials/jguidera_leave_one_out_condition_trials_cross_validation.py
+++ b/src/jguides_2024/time_and_trials/jguidera_leave_one_out_condition_trials_cross_validation.py
@@ -1,7 +1,6 @@
 import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/time_and_trials/jguidera_relative_time_at_well.py
+++ b/src/jguides_2024/time_and_trials/jguidera_relative_time_at_well.py
@@ -3,7 +3,6 @@ import copy
 import datajoint as dj
 import numpy as np
 import pandas as pd
-import spyglass as nd
 import matplotlib.pyplot as plt
 
 from spyglass.common import AnalysisNwbfile

--- a/src/jguides_2024/time_and_trials/jguidera_res_time_bins.py
+++ b/src/jguides_2024/time_and_trials/jguidera_res_time_bins.py
@@ -1,6 +1,5 @@
 import datajoint as dj
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/time_and_trials/jguidera_time_relative_to_well_event.py
+++ b/src/jguides_2024/time_and_trials/jguidera_time_relative_to_well_event.py
@@ -4,7 +4,6 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import spyglass as nd
 
 from spyglass.common import AnalysisNwbfile
 

--- a/src/jguides_2024/utils/interval_helpers.py
+++ b/src/jguides_2024/utils/interval_helpers.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from spyglass.common.common_interval import interval_list_intersect
+from spyglass.common.common_interval import Interval
 
 from jguides_2024.utils.list_helpers import check_lists_same_length
 from jguides_2024.utils.set_helpers import check_membership
@@ -210,7 +210,7 @@ def get_interval_lists_union(interval_lists, verbose=False):
 
 def combine_interval_lists(interval_list_1, interval_list_2, operation, verbose=False):
     if operation == "intersection":
-        return interval_list_intersect(np.asarray(interval_list_1), np.asarray(interval_list_2))
+        return Interval(np.asarray(interval_list_1)).intersect(np.asarray(interval_list_2)).times
     elif operation == "union":
         return get_interval_lists_union([interval_list_1, interval_list_2], verbose=verbose)
 


### PR DESCRIPTION
This PR...

1. Removes unused outdated references to spyglass as `nd`
2. Replaces existing pure-function calls of `fetch_nwb` in favor of the mixin variant
3. Replaces `interval_list_intersect` with `Interval.intersect`